### PR TITLE
Info{Struct,Njis} import fix

### DIFF
--- a/schema/opmonlib/InfoNljs.hpp.j2
+++ b/schema/opmonlib/InfoNljs.hpp.j2
@@ -5,7 +5,7 @@
  * This contains functions struct and other type definitions for shema in 
  * {{cppm.ns(model)}} to be serialized via nlohmann::json.
  */
-{% set tcname = "Nljs" %}
+{% set tcname = "InfoNljs" %}
 #ifndef {{cppm.headerguard(model, tcname)}}
 #define {{cppm.headerguard(model, tcname)}}
 

--- a/schema/opmonlib/InfoStructs.hpp.j2
+++ b/schema/opmonlib/InfoStructs.hpp.j2
@@ -6,7 +6,7 @@
  * This contains struct and other type definitions for shema in 
  * {{cppm.ns(model)}}.
  */
-{% set tcname = "Structs" %}
+{% set tcname = "InfoStructs" %}
 #ifndef {{cppm.headerguard(model, tcname)}}
 #define {{cppm.headerguard(model, tcname)}}
 

--- a/schema/opmonlib/info_hpp_macros.j2
+++ b/schema/opmonlib/info_hpp_macros.j2
@@ -2,7 +2,7 @@
 {% import 'ocpp.hpp.j2' as cppm %}
 
 {% macro declare_sequence(model, t) %}
-using {{t.name}} = {{model.lang.types.sequence}}<{{t["items"]|replace(".","::")}}>;
+{{ cppm.declare_sequence(model, t) }}
 {%- endmacro -%}
 
 {% macro declare_record(model, t) %}


### PR DESCRIPTION
This PR updated InfoNjis and InfoStruct templates to use the correct hpp name… for external imports.